### PR TITLE
Add useful information about usage of \graphicspath{} and add direct link to figure used in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Met behulp van de `graphicx` package kun je eenvoudig afbeeldingen invoegen en a
 In dit gedeelte leer je hoe je figuren correct in je document kunt plaatsen, hoe je meerdere figuren naast elkaar kunt weergeven, en hoe je onderschriften en labels toevoegt voor referenties.
 
 ## Figure Environment
-Wil je een figuur toevoegen aan jouw document dan kan dit met de `figure` environment die met de `graphicx` package beschikbaar is. Overweeg om eventueel [pikachu_transparent.png](https://raw.githubusercontent.com/Allyson-Robert/filii-latex/refs/heads/main/img/pikachu_transparent.png) te gebruiken.
+Wil je een figuur toevoegen aan jouw document dan kan dit met de `figure` environment die met de `graphicx` package beschikbaar is. Overweeg eventueel [pikachu_transparent.png](https://raw.githubusercontent.com/Allyson-Robert/filii-latex/refs/heads/main/img/pikachu_transparent.png) te gebruiken.
 ```latex
 \usepackage{graphicx}
 \usepackage{float}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Met behulp van de `graphicx` package kun je eenvoudig afbeeldingen invoegen en a
 In dit gedeelte leer je hoe je figuren correct in je document kunt plaatsen, hoe je meerdere figuren naast elkaar kunt weergeven, en hoe je onderschriften en labels toevoegt voor referenties.
 
 ## Figure Environment
-Wil je een figuur toevoegen aan jouw document dan kan dit met de `figure` environment die met de `graphicx` package beschikbaar is.
+Wil je een figuur toevoegen aan jouw document dan kan dit met de `figure` environment die met de `graphicx` package beschikbaar is. Overweeg om eventueel [pikachu_transparent.png](https://raw.githubusercontent.com/Allyson-Robert/filii-latex/refs/heads/main/img/pikachu_transparent.png) te gebruiken.
 ```latex
 \usepackage{graphicx}
 \usepackage{float}
@@ -126,6 +126,13 @@ Wil je een figuur toevoegen aan jouw document dan kan dit met de `figure` enviro
 Merk op dat er in dit voorbeeld een caption en label aanwezig zijn.
 Je figuren dienen in verslagen steeds een woordje uitleg te bevatten om de lezer te begeleiden bij het interpreteren van de figuur.
 Zie ook dat er gebruik gemaakt is van de `float` package, deze zorgt ervoor dat figuren exact staan waar je ze wil.
+
+Het is ook mogelijk om het pad waarin de figuren zich begeven te defineren zodat je enkel nog de bestandsnaam moet ingeven, bijvoorbeeld voor de `img` map.
+```latex
+\graphicspath{img/}
+…
+  \includegraphics[width=\textwidth]{pikachu_transparent.png}
+```
 
 ## Minipages
 Wil je meerdere figuren naast of onder elkaar plaatsen dan is de `minipage` package wat je zoekt.


### PR DESCRIPTION
In het geval dat de workshop stap per stap wordt gevolgd op [allyson-robert.github.io/filii-latex](https://allyson-robert.github.io/filii-latex/), wordt nergens aangegeven waar de pikachu afbeelding gevonden kan worden. Ik voeg een suggestie toe om de afbeelding uit de repository te gebruiken om zo het voorbeeld sluitend te maken. 

Daarnaast lijkt het nuttig om kort `\graphicspath ` te vermelden om zo de ingave korter te maken voor afbeeldingen in bepaalde mappen zoals /img. Eventueel ook algemeen vermelden dat, ` \graphicspath{{map1/}{map2/}{map3/}...{mapn/}}` ook geldig is maar ik denk dat dit misschien te afleidend is voor een eerste introductie.
